### PR TITLE
Pin Docker `:latest` image tags to digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM gst-ubuntu-18.04:latest AS OS
+FROM gst-ubuntu-18.04:latest@sha256:48fa9f1f85c0794d297853aba8922e6f123f36fd4a925e5f6c6605b8ae1309c8 AS OS
 ENTRYPOINT /nvidia/run.sh
 CMD /bin/bash


### PR DESCRIPTION
The `:latest` tag changes, so future pulls of this image may retrieve a different image
with different (and possibly erroneous, unexpected, or dangerous) behavior.

Pin the image to an [image digest](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier)
for deterministic behavior.

*See also: [Hadolint error DL3007](https://github.com/hadolint/hadolint/wiki/DL3007).*

[_Created by Sourcegraph batch change `kevin.matthews/pin-docker-base-images`._](https://demo.sourcegraph.com/users/kevin.matthews/batch-changes/pin-docker-base-images)